### PR TITLE
fix index_member in dataservice

### DIFF
--- a/jaqs/data/dataservice.py
+++ b/jaqs/data/dataservice.py
@@ -845,7 +845,7 @@ class RemoteDataService(with_metaclass(Singleton, DataService)):
         for sec, df in gp:
             mask = np.zeros_like(dates, dtype=np.integer)
             for idx, row in df.iterrows():
-                bool_index = np.logical_and(dates > row['in_date'], dates < row['out_date'])
+                bool_index = np.logical_and(dates >= row['in_date'], dates <= row['out_date'])
                 mask[bool_index] = 1
             dic[sec] = mask
             


### PR DESCRIPTION
通过测试发现，在计算某个日期的指数成分股时，只有包含进入日期和退出日期才能得到正确的成分股数量。换句话说，取到的indexCon数据中，在in_date这一天，成分股已经进入指数，在out_date这一天，还没有退出。